### PR TITLE
use oidc sub

### DIFF
--- a/app/client/models/gristUrlState.ts
+++ b/app/client/models/gristUrlState.ts
@@ -97,14 +97,15 @@ export function getWelcomeHomeUrl() {
   return _buildUrl('welcome/home').href;
 }
 
-const FINAL_PATHS = ['/signed-out', '/account-deleted'];
+const PATHS_TO_EXCLUDE_FROM_NEXT = ['/signed-out', '/account-deleted', '/oauth2/callback'];
 
-// Returns the relative URL (i.e. path) of the current page, except when it's the
-// "/signed-out" page or "/account-deleted", in which case it returns the home page ("/").
+// Returns the relative URL (i.e. path) of the current page, except when it's a page
+// that does not make sense to return to after login, such as "/signed-out"
+// or "/account-deleted", in which case it returns the home page("/").
 // This is a good URL to use for a post-login redirect.
-function _getCurrentUrl(): string {
+function _getPostLoginTargetUrl(): string {
   const {hash, pathname, search} = new URL(window.location.href);
-  if (FINAL_PATHS.some(final => pathname.endsWith(final))) { return '/'; }
+  if (PATHS_TO_EXCLUDE_FROM_NEXT.some(path => pathname.endsWith(path))) { return '/'; }
 
   return parseFirstUrlPart('o', pathname).path + search + hash;
 }
@@ -114,7 +115,7 @@ function _getLoginLogoutUrl(
   page: 'login'|'logout'|'signin'|'signup'|'account-deleted',
   options: GetLoginOrSignupUrlOptions = {}
 ): string {
-  const {srcDocId, nextUrl = _getCurrentUrl()} = options;
+  const {srcDocId, nextUrl = _getPostLoginTargetUrl()} = options;
   const startUrl = _buildUrl(page);
   if (srcDocId) { startUrl.searchParams.set('srcDocId', srcDocId); }
   if (nextUrl) { startUrl.searchParams.set('next', nextUrl); }

--- a/app/server/lib/BrowserSession.ts
+++ b/app/server/lib/BrowserSession.ts
@@ -42,6 +42,8 @@ export interface SessionUserObj {
   // State for SAML-mediated logins.
   samlNameId?: string;
   samlSessionIndex?: string;
+
+  oidc?: SessionOIDCInfo;
 }
 
 // Session state maintained for a particular browser. It is identified by a cookie. There may be
@@ -68,8 +70,6 @@ export interface SessionObj {
                           // anonymous editing (e.g. to allow the user to edit
                           // something they just added, without allowing the suer
                           // to edit other people's contributions).
-
-  oidc?: SessionOIDCInfo;
 }
 
 export interface SessionOIDCInfo {

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -279,18 +279,17 @@ export class OIDCConfig {
     });
   }
 
-  public async getLogoutRedirectUrl(req: express.Request): Promise<string> {
+  public async getLogoutRedirectUrl(req: express.Request, redirectUrl: URL): Promise<string> {
     const session: SessionObj|undefined = (req as RequestWithLogin).session;
-    const stableRedirectUri = new URL('/signed-out', getOriginUrl(req)).href;
     // For IdPs that don't have end_session_endpoint, we just redirect to the logout page.
     if (this._skipEndSessionEndpoint) {
-      // Ignore redirectUrl because OIDC providers don't allow variable redirect URIs
-      return stableRedirectUri;
+      return redirectUrl.href;
     }
     // Alternatively, we could use a logout URL specified by configuration.
     if (this._endSessionEndpoint) {
       return this._endSessionEndpoint;
     }
+    const stableRedirectUri = new URL('/signed-out', getOriginUrl(req)).href;
     return this._client.endSessionUrl({
       // Ignore redirectUrl because OIDC providers don't allow variable redirect URIs
       post_logout_redirect_uri: stableRedirectUri,

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -108,7 +108,7 @@ export class OIDCConfig {
     return config;
   }
 
-  protected _client: Client;
+  private _client: Client;
   private _redirectUrl: string;
   private _namePropertyKey?: string;
   private _emailPropertyKey: string;
@@ -118,7 +118,7 @@ export class OIDCConfig {
   private _protectionManager: ProtectionsManager;
   private _acrValues?: string;
 
-  protected constructor(
+  public constructor(
     private _sendAppPage: SendAppPageFunction,
     private _sessions: Sessions,
   ) {}
@@ -308,7 +308,7 @@ export class OIDCConfig {
     return this._protectionManager.supportsProtection(protection);
   }
 
-  protected async _initClient({ issuerUrl, clientId, clientSecret, extraMetadata }:
+  private async _initClient({ issuerUrl, clientId, clientSecret, extraMetadata }:
     { issuerUrl: string, clientId: string, clientSecret: string, extraMetadata: Partial<ClientMetadata> }
   ): Promise<void> {
     const issuer = await Issuer.discover(issuerUrl);

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -205,10 +205,10 @@ export class OIDCConfig {
       log.warn("OIDCConfig callback:", err.message);
       return this._sendErrorPage(req, res);
     }
-    
+
     try {
       const params = this._client.callbackParams(req);
-      
+
       const { oidc: oidcInfo } = await scopedSession.getScopedSession();
 
       if (!oidcInfo) {
@@ -237,7 +237,7 @@ export class OIDCConfig {
       const profile = this._makeUserProfileFromUserInfo(userInfo);
       log.info(`OIDCConfig: got OIDC response for ${profile.email} (${profile.name}) redirecting to ${targetUrl}`);
 
-      await scopedSession.updateUser(req,{
+      await scopedSession.updateUser(req, {
         profile,
         // We clear the previous session info, like the states, nonce or the code verifier, which
         // now that we are authenticated.
@@ -272,7 +272,7 @@ export class OIDCConfig {
       targetUrl: targetUrl.href,
       ...this._protectionManager.generateSessionInfo()
     };
-    
+
     await scopedSession.updateUser(req, {
       oidc: oidcInfo,
     });

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -193,14 +193,14 @@ export class OIDCConfig {
     log.info(`OIDCConfig: initialized with issuer ${issuerUrl}`);
   }
 
-  public addEndpoints(app: express.Application, sessions: Sessions): void {
-    app.get(CALLBACK_URL, this.handleCallback.bind(this, sessions));
+  public addEndpoints(app: express.Application): void {
+    app.get(CALLBACK_URL, this.handleCallback.bind(this));
   }
 
-  public async handleCallback(sessions: Sessions, req: express.Request, res: express.Response): Promise<void> {
+  public async handleCallback(req: express.Request, res: express.Response): Promise<void> {
     let scopedSession;
     try {
-      scopedSession = sessions.getOrCreateSessionFromRequest(req);
+      scopedSession = this._sessions.getOrCreateSessionFromRequest(req);
     } catch(err) {
       log.warn("OIDCConfig callback:", err.message);
       return this._sendErrorPage(req, res);
@@ -416,7 +416,7 @@ export async function getOIDCLoginSystem(): Promise<GristLoginSystem | undefined
         getSignUpRedirectUrl: config.getLoginRedirectUrl.bind(config),
         getLogoutRedirectUrl: config.getLogoutRedirectUrl.bind(config),
         async addEndpoints(app: express.Express) {
-          config.addEndpoints(app, gristServer.getSessions());
+          config.addEndpoints(app);
           return 'oidc';
         },
       };

--- a/test/client/models/gristUrlState.ts
+++ b/test/client/models/gristUrlState.ts
@@ -399,5 +399,12 @@ describe('gristUrlState', function() {
       setWindowLocation('https://docs.getgrist.com/signed-out');
       assert.equal(getLoginUrl(), 'https://docs.getgrist.com/login?next=%2F');
     });
+
+    it('getLoginUrl should skip encoding redirect url on oauth2 callback page', function() {
+      setWindowLocation('http://localhost:8080/oauth2/callback?error=something');
+      assert.equal(getLoginUrl(), 'http://localhost:8080/o/docs/login?next=%2F');
+      setWindowLocation('https://docs.getgrist.com/oauth2/callback?error=something');
+      assert.equal(getLoginUrl(), 'https://docs.getgrist.com/login?next=%2F');
+    });
   });
 });

--- a/test/client/models/gristUrlState.ts
+++ b/test/client/models/gristUrlState.ts
@@ -402,7 +402,7 @@ describe('gristUrlState', function() {
 
     it('getLoginUrl should skip encoding redirect url on oauth2 callback page', function() {
       setWindowLocation('http://localhost:8080/oauth2/callback?error=something');
-      assert.equal(getLoginUrl(), 'http://localhost:8080/o/docs/login?next=%2F');
+      assert.equal(getLoginUrl(), 'http://localhost:8080/login?next=%2F');
       setWindowLocation('https://docs.getgrist.com/oauth2/callback?error=something');
       assert.equal(getLoginUrl(), 'https://docs.getgrist.com/login?next=%2F');
     });

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -752,6 +752,7 @@ describe('OIDCConfig', () => {
   });
 
   describe('getLogoutRedirectUrl', () => {
+    const REDIRECT_URL = new URL('http://localhost:8484/docs/signed-out');
     const STABLE_LOGOUT_URL = new URL('http://localhost:8484/signed-out');
     const URL_RETURNED_BY_CLIENT = 'http://localhost:8484/logout_url_from_issuer';
     const ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT = 'http://localhost:8484/logout';
@@ -767,7 +768,7 @@ describe('OIDCConfig', () => {
         env: {
           GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT: 'true',
         },
-        expectedUrl: STABLE_LOGOUT_URL.href,
+        expectedUrl: REDIRECT_URL.href,
       }, {
         itMsg: 'should use the GRIST_OIDC_IDP_END_SESSION_ENDPOINT when it is set',
         env: {
@@ -803,7 +804,7 @@ describe('OIDCConfig', () => {
           },
           session: 'session' in ctx ? ctx.session : FAKE_SESSION
         } as unknown as RequestWithLogin;
-        const url = await config.getLogoutRedirectUrl(req);
+        const url = await config.getLogoutRedirectUrl(req, REDIRECT_URL);
         assert.equal(url, ctx.expectedUrl);
         if (ctx.expectedLogoutParams) {
           assert.isTrue(clientStub.endSessionUrl.calledOnce);

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -83,7 +83,7 @@ class FakeSessions {
   }
 
 
-  asSessions(): Sessions {
+  public asSessions(): Sessions {
     return this as unknown as Sessions;
   }
 }

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -72,7 +72,7 @@ class FakeSessions {
     this.user = _.clone(initialUser);
   }
 
-  getOrCreateSessionFromRequest(): ScopedSession {
+  public getOrCreateSessionFromRequest(): ScopedSession {
     return {
       getScopedSession: async () => _.clone(this.user),
 

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -15,7 +15,7 @@ const NOOPED_SEND_APP_PAGE: SendAppPageFunction = () => Promise.resolve();
 class OIDCConfigStubbed extends OIDCConfig {
   public static async buildWithStub(
     client: Client = new ClientStub().asClient(),
-    sessions: Sessions = null as unknown as Sessions
+    sessions: Sessions = new FakeSessions().asSessions()
   ) {
     return this.build(
       NOOPED_SEND_APP_PAGE,
@@ -25,7 +25,7 @@ class OIDCConfigStubbed extends OIDCConfig {
   }
   public static async build(
     sendAppPage: SendAppPageFunction,
-    sessions: Sessions = null as unknown as Sessions,
+    sessions: Sessions = new FakeSessions().asSessions(),
     clientStub?: Client
   ): Promise<OIDCConfigStubbed> {
     const result = new OIDCConfigStubbed(sendAppPage, sessions);
@@ -700,7 +700,7 @@ describe('OIDCConfig', () => {
         };
         const config = await OIDCConfigStubbed.build(
           sendAppPageStub as SendAppPageFunction,
-          null as unknown as Sessions,
+          fakeSessions.asSessions(),
           clientStub.asClient()
         );
         clientStub.callbackParams.returns(fakeParams);
@@ -713,7 +713,6 @@ describe('OIDCConfig', () => {
           t: (key: string) => key
         } as unknown as express.Request;
         await config.handleCallback(
-          fakeSessions.asSessions(),
           req,
           fakeRes as unknown as express.Response
         );
@@ -750,7 +749,7 @@ describe('OIDCConfig', () => {
       const sendAppPageStub = Sinon.stub().resolves();
       const config = await OIDCConfigStubbed.build(
         sendAppPageStub,
-        null as unknown as Sessions,
+        fakeSessions.asSessions(),
         clientStub.asClient()
       );
       const req = {} as unknown as express.Request;
@@ -766,7 +765,6 @@ describe('OIDCConfig', () => {
 
       fakeSessions.userSession = _.clone(DEFAULT_SESSION);
       await config.handleCallback(
-        fakeSessions.asSessions(),
         req,
         fakeRes as unknown as express.Response
       );

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -79,9 +79,12 @@ class FakeSessions {
         op: (user: SessionUserObj) => Promise<SessionUserObj>
       ) => {
         this.userSession = await op(this.userSession);
-      }
+      },
+
+      getScopedSession: async () => this.userSession,
     } as unknown as ScopedSession;
   }
+
 
   asSessions(): Sessions {
     return this as unknown as Sessions;

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -1,6 +1,6 @@
 import {EnvironmentSnapshot} from "../testUtils";
 import {OIDCConfig} from "app/server/lib/OIDCConfig";
-import {SessionObj} from "app/server/lib/BrowserSession";
+import {SessionUserObj} from "app/server/lib/BrowserSession";
 import {Sessions} from "app/server/lib/Sessions";
 import log from "app/server/lib/log";
 import {assert} from "chai";
@@ -14,11 +14,22 @@ import { SendAppPageFunction } from "app/server/lib/sendAppPage";
 const NOOPED_SEND_APP_PAGE: SendAppPageFunction = () => Promise.resolve();
 
 class OIDCConfigStubbed extends OIDCConfig {
-  public static async buildWithStub(client: Client = new ClientStub().asClient()) {
-    return this.build(NOOPED_SEND_APP_PAGE, client);
+  public static async buildWithStub(
+    client: Client = new ClientStub().asClient(),
+    sessions: Sessions = null as unknown as Sessions
+  ) {
+    return this.build(
+      NOOPED_SEND_APP_PAGE,
+      sessions,
+      client
+    );
   }
-  public static async build(sendAppPage: SendAppPageFunction, clientStub?: Client): Promise<OIDCConfigStubbed> {
-    const result = new OIDCConfigStubbed(sendAppPage);
+  public static async build(
+    sendAppPage: SendAppPageFunction,
+    sessions: Sessions = null as unknown as Sessions,
+    clientStub?: Client
+  ): Promise<OIDCConfigStubbed> {
+    const result = new OIDCConfigStubbed(sendAppPage, sessions);
     if (clientStub) {
       result._initClient = Sinon.spy(() => {
         result._client = clientStub!;
@@ -107,7 +118,7 @@ describe('OIDCConfig', () => {
       ]) {
         setEnvVars();
         delete process.env[envVar];
-        const promise = OIDCConfig.build(NOOPED_SEND_APP_PAGE);
+        const promise = OIDCConfig.build(NOOPED_SEND_APP_PAGE, null as unknown as Sessions);
         await assert.isRejected(promise, `missing environment variable: ${envVar}`);
       }
     });
@@ -253,7 +264,7 @@ describe('OIDCConfig', () => {
     it('should reject when GRIST_OIDC_IDP_ENABLED_PROTECTIONS contains unsupported values', async () => {
       setEnvVars();
       process.env.GRIST_OIDC_IDP_ENABLED_PROTECTIONS = 'STATE,NONCE,PKCE,invalid';
-      const promise = OIDCConfig.build(NOOPED_SEND_APP_PAGE);
+      const promise = OIDCConfig.build(NOOPED_SEND_APP_PAGE, null as unknown as Sessions);
       await checkRejection(promise, 'invalid');
     });
 
@@ -398,16 +409,30 @@ describe('OIDCConfig', () => {
         setEnvVars();
         Object.assign(process.env, ctx.env);
         const clientStub = new ClientStub();
-        const config = await OIDCConfigStubbed.buildWithStub(clientStub.asClient());
-        const session = {};
-        const req = {
-          session
-        } as unknown as express.Request;
+        const req = {} as unknown as express.Request;
+        let userSession: SessionUserObj = {};
+        const fakeSessions = {
+          getOrCreateSessionFromRequest: () => ({
+            operateOnScopedSession: async (
+              req: Request,
+              op: (user: SessionUserObj) => Promise<SessionUserObj>
+            ) => {
+              userSession = await op(userSession);
+            },
+          }),
+        } as unknown as Sessions;
+        const config = await OIDCConfigStubbed.buildWithStub(
+          clientStub.asClient(),
+          fakeSessions
+        );
+
+        fakeSessions;
         const url = await config.getLoginRedirectUrl(req, new URL(TARGET_URL));
+
         assert.equal(url, ClientStub.FAKE_REDIRECT_URL);
         assert.isTrue(clientStub.authorizationUrl.calledOnce);
         assert.deepEqual(clientStub.authorizationUrl.firstCall.args, ctx.expectedCalledWith);
-        assert.deepEqual(session, ctx.expectedSession);
+        assert.deepEqual(userSession.oidc, ctx.expectedSession.oidc);
       });
     });
   });
@@ -421,12 +446,12 @@ describe('OIDCConfig', () => {
       name: 'fake-name',
       email_verified: true,
     };
-    const DEFAULT_SESSION = {
+    const DEFAULT_SESSION: SessionUserObj = {
       oidc: {
         code_verifier: FAKE_CODE_VERIFIER,
-        state: FAKE_STATE
-      }
-    } as SessionObj;
+        state: FAKE_STATE,
+      },
+    };
     const DEFAULT_EXPECTED_CALLBACK_CHECKS = {
       state: FAKE_STATE,
       code_verifier: FAKE_CODE_VERIFIER,
@@ -436,12 +461,17 @@ describe('OIDCConfig', () => {
       send: Sinon.SinonStub;
       redirect: Sinon.SinonStub;
     };
-    let fakeSessions: {
-      getOrCreateSessionFromRequest: Sinon.SinonStub
-    };
-    let fakeScopedSession: {
-      operateOnScopedSession: Sinon.SinonStub
-    };
+    let userSession: SessionUserObj = {};
+    const fakeSessions = {
+      getOrCreateSessionFromRequest: () => ({
+        operateOnScopedSession: async (
+          req: Request,
+          op: (user: SessionUserObj) => Promise<SessionUserObj>
+        ) => {
+          userSession = await op(userSession);
+        },
+      }),
+    } as unknown as Sessions;
 
     beforeEach(() => {
       fakeRes = {
@@ -449,12 +479,7 @@ describe('OIDCConfig', () => {
         status: Sinon.stub().returnsThis(),
         send: Sinon.stub().returnsThis(),
       };
-      fakeScopedSession = {
-        operateOnScopedSession: Sinon.stub().resolves(),
-      };
-      fakeSessions = {
-        getOrCreateSessionFromRequest: Sinon.stub().returns(fakeScopedSession),
-      };
+      userSession = {};
     });
 
     function checkUserProfile(expectedUserProfile: object) {
@@ -672,21 +697,22 @@ describe('OIDCConfig', () => {
         const fakeParams = {
           state: FAKE_STATE,
         };
-        const config = await OIDCConfigStubbed.build(sendAppPageStub as SendAppPageFunction, clientStub.asClient());
-        const session = _.clone(ctx.session); // session is modified, so clone it
-        const req = {
-          session,
-          t: (key: string) => key
-        } as unknown as express.Request;
+        const config = await OIDCConfigStubbed.build(
+          sendAppPageStub as SendAppPageFunction,
+          null as unknown as Sessions,
+          clientStub.asClient()
+        );
         clientStub.callbackParams.returns(fakeParams);
         const tokenSet = { id_token: 'id_token', ...ctx.tokenSet };
         clientStub.callback.resolves(tokenSet);
         clientStub.userinfo.returns(_.clone(ctx.userInfo ?? FAKE_USER_INFO));
-        const user: { profile?: object } = {};
-        fakeScopedSession.operateOnScopedSession.yields(user);
-
+        userSession = { oidc: _.clone(ctx.session.oidc) }; // session is modified, so clone it
+        
+        const req = {
+          t: (key: string) => key
+        } as unknown as express.Request;
         await config.handleCallback(
-          fakeSessions as unknown as Sessions,
+          fakeSessions,
           req,
           fakeRes as unknown as express.Response
         );
@@ -708,13 +734,11 @@ describe('OIDCConfig', () => {
             fakeParams,
             ctx.expectedCbChecks ?? DEFAULT_EXPECTED_CALLBACK_CHECKS
           ]);
-          assert.deepEqual(session, {
-            oidc: {
-              idToken: tokenSet.id_token,
-            }
+          assert.deepEqual(userSession.oidc, {
+            idToken: tokenSet.id_token,
           }, 'oidc info should only keep state and id_token in the session and for the logout');
         }
-        ctx.extraChecks?.({ fakeRes, user, sendAppPageStub });
+        ctx.extraChecks?.({ fakeRes, user: userSession, sendAppPageStub });
       });
     });
 
@@ -723,10 +747,12 @@ describe('OIDCConfig', () => {
       setEnvVars();
       const clientStub = new ClientStub();
       const sendAppPageStub = Sinon.stub().resolves();
-      const config = await OIDCConfigStubbed.build(sendAppPageStub, clientStub.asClient());
-      const req = {
-        session: DEFAULT_SESSION,
-      } as unknown as express.Request;
+      const config = await OIDCConfigStubbed.build(
+        sendAppPageStub,
+        null as unknown as Sessions,
+        clientStub.asClient()
+      );
+      const req = {} as unknown as express.Request;
       clientStub.callbackParams.returns({state: FAKE_STATE});
       const errorResponse = {
         body: { property: 'response here' },
@@ -737,13 +763,16 @@ describe('OIDCConfig', () => {
       const err = new OIDCError.OPError({error: 'userinfo failed'}, errorResponse);
       clientStub.userinfo.rejects(err);
 
+      userSession = _.clone(DEFAULT_SESSION);
       await config.handleCallback(
-        fakeSessions as unknown as Sessions,
+        fakeSessions,
         req,
         fakeRes as unknown as express.Response
       );
 
-      assert.equal(logErrorStub.callCount, 2, 'logErrorStub show be called twice');
+      assert.isUndefined(userSession.oidc);
+
+      assert.equal(logErrorStub.callCount, 2, 'logErrorStub should be called twice');
       assert.include(logErrorStub.firstCall.args[0], err.message);
       assert.include(logErrorStub.secondCall.args[0], 'Response received');
       assert.deepEqual(logErrorStub.secondCall.args[1], errorResponse);
@@ -756,11 +785,11 @@ describe('OIDCConfig', () => {
     const STABLE_LOGOUT_URL = new URL('http://localhost:8484/signed-out');
     const URL_RETURNED_BY_CLIENT = 'http://localhost:8484/logout_url_from_issuer';
     const ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT = 'http://localhost:8484/logout';
-    const FAKE_SESSION = {
+    const FAKE_SESSION: SessionUserObj = {
       oidc: {
         idToken: 'id_token',
       }
-    } as SessionObj;
+    };
 
     [
       {
@@ -783,13 +812,13 @@ describe('OIDCConfig', () => {
           id_token_hint: FAKE_SESSION.oidc!.idToken,
         }
       }, {
-        itMsg: 'should call the end session endpoint with no idToken if session is missing',
+        itMsg: 'should call the end session endpoint with no idToken if session oidc info is missing',
         expectedUrl: URL_RETURNED_BY_CLIENT,
         expectedLogoutParams: {
           post_logout_redirect_uri: STABLE_LOGOUT_URL.href,
           id_token_hint: undefined,
         },
-        session: null
+        session: { } as SessionUserObj
       }
     ].forEach(ctx => {
       it(ctx.itMsg, async () => {
@@ -797,12 +826,22 @@ describe('OIDCConfig', () => {
         Object.assign(process.env, ctx.env);
         const clientStub = new ClientStub();
         clientStub.endSessionUrl.returns(URL_RETURNED_BY_CLIENT);
-        const config = await OIDCConfigStubbed.buildWithStub(clientStub.asClient());
+        let userSession: SessionUserObj = _.clone(ctx.session ?? FAKE_SESSION);
+        const fakeSessions = {
+          getOrCreateSessionFromRequest: () => ({
+            operateOnScopedSession: async (
+              req: Request,
+              op: (user: SessionUserObj) => Promise<SessionUserObj>
+            ) => {
+              userSession = await op(userSession);
+            },
+          }),
+        } as unknown as Sessions;
+        const config = await OIDCConfigStubbed.buildWithStub(clientStub.asClient(), fakeSessions);
         const req = {
           headers: {
             host: STABLE_LOGOUT_URL.host
           },
-          session: 'session' in ctx ? ctx.session : FAKE_SESSION
         } as unknown as RequestWithLogin;
         const url = await config.getLogoutRedirectUrl(req, REDIRECT_URL);
         assert.equal(url, ctx.expectedUrl);


### PR DESCRIPTION
- **getLogoutRedirectUrl minor improvements**
- **avoid using oidc callback URL as post-login URL**
- **Move oidc session info from SessionObj to SessionUserObj**
- **OIDCConfig test refactoring**
- **OIDCConfig refactoring**
- **use getScopedSession for read-only access**
- **stop using operateOnScopedSession**
