### PR TITLE
move oidc state to sessionuser

### DIFF
--- a/app/server/lib/BrowserSession.ts
+++ b/app/server/lib/BrowserSession.ts
@@ -42,6 +42,8 @@ export interface SessionUserObj {
   // State for SAML-mediated logins.
   samlNameId?: string;
   samlSessionIndex?: string;
+
+  oidc?: SessionOIDCInfo;
 }
 
 // Session state maintained for a particular browser. It is identified by a cookie. There may be
@@ -68,8 +70,6 @@ export interface SessionObj {
                           // anonymous editing (e.g. to allow the user to edit
                           // something they just added, without allowing the suer
                           // to edit other people's contributions).
-
-  oidc?: SessionOIDCInfo;
 }
 
 export interface SessionOIDCInfo {

--- a/app/server/lib/BrowserSession.ts
+++ b/app/server/lib/BrowserSession.ts
@@ -30,7 +30,7 @@ export interface SessionUserObj {
    */
   authSubject?: string;
 
-  // [UNUSED] Login ID token used to access AWS services.
+  // Login ID token from auth provider
   idToken?: string;
 
   // Login access token used to access other AWS services.
@@ -43,7 +43,6 @@ export interface SessionUserObj {
   samlNameId?: string;
   samlSessionIndex?: string;
 
-  oidc?: SessionOIDCInfo;
 }
 
 // Session state maintained for a particular browser. It is identified by a cookie. There may be
@@ -70,6 +69,8 @@ export interface SessionObj {
                           // anonymous editing (e.g. to allow the user to edit
                           // something they just added, without allowing the suer
                           // to edit other people's contributions).
+
+  oidc?: SessionOIDCInfo;
 }
 
 export interface SessionOIDCInfo {
@@ -82,8 +83,6 @@ export interface SessionOIDCInfo {
   // state is used to protect against Error Responses spoofs.
   state?: string;
   targetUrl?: string;
-  // Stores user claims signed by the issuer, store it to allow loging out.
-  idToken?: string;
 }
 
 // Make an artificial change to a session to encourage express-session to set a cookie.

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -73,12 +73,10 @@ import {
 import { Sessions } from './Sessions';
 import log from 'app/server/lib/log';
 import { AppSettings, appSettings } from './AppSettings';
-import { RequestWithLogin } from './Authorizer';
 import { UserProfile } from 'app/common/LoginSessionAPI';
 import { SendAppPageFunction } from 'app/server/lib/sendAppPage';
 import { StringUnionError } from 'app/common/StringUnion';
 import { EnabledProtection, EnabledProtectionString, ProtectionsManager } from './oidc/Protections';
-import { SessionObj } from './BrowserSession';
 import { getOriginUrl } from './requestUtils';
 
 const CALLBACK_URL = '/oauth2/callback';
@@ -104,13 +102,13 @@ export class OIDCConfig {
   /**
    * Handy alias to create an OIDCConfig instance and initialize it.
    */
-  public static async build(sendAppPage: SendAppPageFunction): Promise<OIDCConfig> {
-    const config = new OIDCConfig(sendAppPage);
+  public static async build(sendAppPage: SendAppPageFunction, sessions: Sessions): Promise<OIDCConfig> {
+    const config = new OIDCConfig(sendAppPage, sessions);
     await config.initOIDC();
     return config;
   }
 
-  protected _client: Client;
+  private _client: Client;
   private _redirectUrl: string;
   private _namePropertyKey?: string;
   private _emailPropertyKey: string;
@@ -120,8 +118,9 @@ export class OIDCConfig {
   private _protectionManager: ProtectionsManager;
   private _acrValues?: string;
 
-  protected constructor(
-    private _sendAppPage: SendAppPageFunction
+  public constructor(
+    private _sendAppPage: SendAppPageFunction,
+    private _sessions: Sessions,
   ) {}
 
   public async initOIDC(): Promise<void> {
@@ -194,14 +193,14 @@ export class OIDCConfig {
     log.info(`OIDCConfig: initialized with issuer ${issuerUrl}`);
   }
 
-  public addEndpoints(app: express.Application, sessions: Sessions): void {
-    app.get(CALLBACK_URL, this.handleCallback.bind(this, sessions));
+  public addEndpoints(app: express.Application): void {
+    app.get(CALLBACK_URL, this.handleCallback.bind(this));
   }
 
-  public async handleCallback(sessions: Sessions, req: express.Request, res: express.Response): Promise<void> {
-    let mreq;
+  public async handleCallback(req: express.Request, res: express.Response): Promise<void> {
+    let scopedSession;
     try {
-      mreq = this._getRequestWithSession(req);
+      scopedSession = this._sessions.getOrCreateSessionFromRequest(req);
     } catch(err) {
       log.warn("OIDCConfig callback:", err.message);
       return this._sendErrorPage(req, res);
@@ -209,13 +208,16 @@ export class OIDCConfig {
 
     try {
       const params = this._client.callbackParams(req);
-      if (!mreq.session.oidc) {
+
+      const { oidc: oidcInfo } = await scopedSession.getScopedSession();
+
+      if (!oidcInfo) {
         throw new Error('Missing OIDC information associated to this session');
       }
 
-      const { targetUrl } = mreq.session.oidc;
+      const { targetUrl } = oidcInfo;
 
-      const checks = this._protectionManager.getCallbackChecks(mreq.session.oidc);
+      const checks = this._protectionManager.getCallbackChecks(oidcInfo);
 
       // The callback function will compare the protections present in the params and the ones we retrieved
       // from the session. If they don't match, it will throw an error.
@@ -235,17 +237,16 @@ export class OIDCConfig {
       const profile = this._makeUserProfileFromUserInfo(userInfo);
       log.info(`OIDCConfig: got OIDC response for ${profile.email} (${profile.name}) redirecting to ${targetUrl}`);
 
-      const scopedSession = sessions.getOrCreateSessionFromRequest(req);
-      await scopedSession.operateOnScopedSession(req, async (user) => Object.assign(user, {
+      await scopedSession.updateUser(req, {
         profile,
-      }));
+        // We clear the previous session info, like the states, nonce or the code verifier, which
+        // now that we are authenticated.
+        // We store the idToken for later, especially for the logout
+        oidc: {
+          idToken: tokenSet.id_token,
+        }
+      });
 
-      // We clear the previous session info, like the states, nonce or the code verifier, which
-      // now that we are authenticated.
-      // We store the idToken for later, especially for the logout
-      mreq.session.oidc = {
-        idToken: tokenSet.id_token,
-      };
       res.redirect(targetUrl ?? '/');
     } catch (err) {
       log.error(`OIDC callback failed: ${err.stack}`);
@@ -258,29 +259,35 @@ export class OIDCConfig {
       // This way, we prevent several login attempts.
       //
       // Also session deletion must be done before sending the response.
-      delete mreq.session.oidc;
+      await scopedSession.updateUser(req, { oidc: undefined });
 
       await this._sendErrorPage(req, res, err.userFriendlyMessage);
     }
   }
 
   public async getLoginRedirectUrl(req: express.Request, targetUrl: URL): Promise<string> {
-    const mreq = this._getRequestWithSession(req);
+    const scopedSession = this._sessions.getOrCreateSessionFromRequest(req);
 
-    mreq.session.oidc = {
+    const oidcInfo = {
       targetUrl: targetUrl.href,
       ...this._protectionManager.generateSessionInfo()
     };
 
+    await scopedSession.updateUser(req, {
+      oidc: oidcInfo,
+    });
+
     return this._client.authorizationUrl({
       scope: process.env.GRIST_OIDC_IDP_SCOPES || 'openid email profile',
       acr_values: this._acrValues,
-      ...this._protectionManager.forgeAuthUrlParams(mreq.session.oidc),
+      ...this._protectionManager.forgeAuthUrlParams(oidcInfo),
     });
   }
 
   public async getLogoutRedirectUrl(req: express.Request, redirectUrl: URL): Promise<string> {
-    const session: SessionObj|undefined = (req as RequestWithLogin).session;
+    const scopedSession = this._sessions.getOrCreateSessionFromRequest(req);
+    const { oidc } = await scopedSession.getScopedSession();
+
     // For IdPs that don't have end_session_endpoint, we just redirect to the requested page.
     if (this._skipEndSessionEndpoint) {
       return redirectUrl.href;
@@ -293,7 +300,7 @@ export class OIDCConfig {
     return this._client.endSessionUrl({
       // Ignore redirectUrl because OIDC providers don't allow variable redirect URIs
       post_logout_redirect_uri: stableRedirectUri,
-      id_token_hint: session?.oidc?.idToken,
+      id_token_hint: oidc?.idToken,
     });
   }
 
@@ -301,7 +308,7 @@ export class OIDCConfig {
     return this._protectionManager.supportsProtection(protection);
   }
 
-  protected async _initClient({ issuerUrl, clientId, clientSecret, extraMetadata }:
+  private async _initClient({ issuerUrl, clientId, clientSecret, extraMetadata }:
     { issuerUrl: string, clientId: string, clientSecret: string, extraMetadata: Partial<ClientMetadata> }
   ): Promise<void> {
     const issuer = await Issuer.discover(issuerUrl);
@@ -323,13 +330,6 @@ export class OIDCConfig {
         errMessage: userFriendlyMessage
       },
     });
-  }
-
-  private _getRequestWithSession(req: express.Request) {
-    const mreq = req as RequestWithLogin;
-    if (!mreq.session) { throw new Error('no session available'); }
-
-    return mreq;
   }
 
   private _buildEnabledProtections(section: AppSettings): Set<EnabledProtectionString> {
@@ -354,21 +354,23 @@ export class OIDCConfig {
     }
   }
 
-  private _makeUserProfileFromUserInfo(userInfo: UserinfoResponse): Partial<UserProfile> {
+  private _makeUserProfileFromUserInfo(userInfo: UserinfoResponse): UserProfile {
     return {
+      // FIXME: do not generate string "undefined"
       email: String(userInfo[this._emailPropertyKey]),
       name: this._extractName(userInfo)
     };
   }
 
-  private _extractName(userInfo: UserinfoResponse): string | undefined {
+  private _extractName(userInfo: UserinfoResponse): string {
+    // FIXME: check for presence of value
     if (this._namePropertyKey) {
-      return (userInfo[this._namePropertyKey] as any)?.toString();
+      return (userInfo[this._namePropertyKey] as any)?.toString() ?? '';
     }
     const fname = userInfo.given_name ?? '';
     const lname = userInfo.family_name ?? '';
 
-    return `${fname} ${lname}`.trim() || userInfo.name;
+    return `${fname} ${lname}`.trim() || userInfo.name || '';
   }
 
   /**
@@ -397,13 +399,13 @@ export async function getOIDCLoginSystem(): Promise<GristLoginSystem | undefined
   if (!process.env.GRIST_OIDC_IDP_ISSUER) { return undefined; }
   return {
     async getMiddleware(gristServer: GristServer) {
-      const config = await OIDCConfig.build(gristServer.sendAppPage.bind(gristServer));
+      const config = await OIDCConfig.build(gristServer.sendAppPage.bind(gristServer), gristServer.getSessions());
       return {
         getLoginRedirectUrl: config.getLoginRedirectUrl.bind(config),
         getSignUpRedirectUrl: config.getLoginRedirectUrl.bind(config),
         getLogoutRedirectUrl: config.getLogoutRedirectUrl.bind(config),
         async addEndpoints(app: express.Express) {
-          config.addEndpoints(app, gristServer.getSessions());
+          config.addEndpoints(app);
           return 'oidc';
         },
       };

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -279,18 +279,17 @@ export class OIDCConfig {
     });
   }
 
-  public async getLogoutRedirectUrl(req: express.Request): Promise<string> {
+  public async getLogoutRedirectUrl(req: express.Request, redirectUrl: URL): Promise<string> {
     const session: SessionObj|undefined = (req as RequestWithLogin).session;
-    const stableRedirectUri = new URL('/signed-out', getOriginUrl(req)).href;
-    // For IdPs that don't have end_session_endpoint, we just redirect to the logout page.
+    // For IdPs that don't have end_session_endpoint, we just redirect to the requested page.
     if (this._skipEndSessionEndpoint) {
-      // Ignore redirectUrl because OIDC providers don't allow variable redirect URIs
-      return stableRedirectUri;
+      return redirectUrl.href;
     }
     // Alternatively, we could use a logout URL specified by configuration.
     if (this._endSessionEndpoint) {
       return this._endSessionEndpoint;
     }
+    const stableRedirectUri = new URL('/signed-out', getOriginUrl(req)).href;
     return this._client.endSessionUrl({
       // Ignore redirectUrl because OIDC providers don't allow variable redirect URIs
       post_logout_redirect_uri: stableRedirectUri,

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -73,6 +73,7 @@ import {
 import { Sessions } from './Sessions';
 import log from 'app/server/lib/log';
 import { AppSettings, appSettings } from './AppSettings';
+import { RequestWithLogin } from './Authorizer';
 import { UserProfile } from 'app/common/LoginSessionAPI';
 import { SendAppPageFunction } from 'app/server/lib/sendAppPage';
 import { StringUnionError } from 'app/common/StringUnion';
@@ -198,26 +199,26 @@ export class OIDCConfig {
   }
 
   public async handleCallback(req: express.Request, res: express.Response): Promise<void> {
-    let scopedSession;
+    let mreq;
     try {
-      scopedSession = this._getSessions().getOrCreateSessionFromRequest(req);
+      mreq = this._getRequestWithSession(req);
     } catch(err) {
       log.warn("OIDCConfig callback:", err.message);
       return this._sendErrorPage(req, res);
     }
 
     try {
-      const params = this._client.callbackParams(req);
+      const oidc = mreq.session.oidc;
 
-      const { oidc: oidcInfo } = await scopedSession.getScopedSession();
-
-      if (!oidcInfo) {
+      if (!oidc) {
         throw new Error('Missing OIDC information associated to this session');
       }
 
-      const { targetUrl } = oidcInfo;
+      const params = this._client.callbackParams(req);
 
-      const checks = this._protectionManager.getCallbackChecks(oidcInfo);
+      const { targetUrl } = oidc;
+
+      const checks = this._protectionManager.getCallbackChecks(oidc);
 
       // The callback function will compare the protections present in the params and the ones we retrieved
       // from the session. If they don't match, it will throw an error.
@@ -237,15 +238,20 @@ export class OIDCConfig {
       const profile = this._makeUserProfileFromUserInfo(userInfo);
       log.info(`OIDCConfig: got OIDC response for ${profile.email} (${profile.name}) redirecting to ${targetUrl}`);
 
+      const scopedSession = this._getSessions().getOrCreateSessionFromRequest(req);
       await scopedSession.updateUser(req, {
         profile,
-        // We clear the previous session info, like the states, nonce or the code verifier, which
-        // now that we are authenticated.
         // We store the idToken for later, especially for the logout
-        oidc: {
-          idToken: tokenSet.id_token,
-        }
+        idToken: tokenSet.id_token,
       });
+
+      // Delete entirely the session OIDC data when the callback is called.
+      // This way, we prevent repeated login attempts.
+      // We have to do this after scopedSession.updateUser, because that
+      // method reads the session data back from the store first.
+      // We also need to do this before redirecting, because the redirect
+      // is what triggers session persistence.
+      delete mreq.session.oidc;
 
       res.redirect(targetUrl ?? '/');
     } catch (err) {
@@ -255,38 +261,39 @@ export class OIDCConfig {
         log.error('Response received: %o',  maybeResponse);
       }
 
-      // Delete entirely the session data when the login failed.
-      // This way, we prevent several login attempts.
-      //
-      // Also session deletion must be done before sending the response.
-      await scopedSession.updateUser(req, { oidc: undefined });
+      // Delete entirely the session OIDC data when the callback is called.
+      // This way, we prevent repeated login attempts.
+      // This is duplicated from the try block above, because we want to do this
+      // even if the try block throws an error. Note that we can't use a finally
+      // block, because the _sendErrorPage call below is what triggers session
+      // persistence, and we need to delete the session data before that.
+      delete mreq.session.oidc;
 
       await this._sendErrorPage(req, res, err.userFriendlyMessage);
     }
   }
 
   public async getLoginRedirectUrl(req: express.Request, targetUrl: URL): Promise<string> {
-    const scopedSession = this._getSessions().getOrCreateSessionFromRequest(req);
+    const mreq = this._getRequestWithSession(req);
 
-    const oidcInfo = {
+    const oidc = {
       targetUrl: targetUrl.href,
       ...this._protectionManager.generateSessionInfo()
     };
 
-    await scopedSession.updateUser(req, {
-      oidc: oidcInfo,
-    });
+    mreq.session.oidc = oidc;
 
     return this._client.authorizationUrl({
       scope: process.env.GRIST_OIDC_IDP_SCOPES || 'openid email profile',
       acr_values: this._acrValues,
-      ...this._protectionManager.forgeAuthUrlParams(oidcInfo),
+      ...this._protectionManager.forgeAuthUrlParams(oidc),
     });
   }
 
   public async getLogoutRedirectUrl(req: express.Request, redirectUrl: URL): Promise<string> {
     const scopedSession = this._getSessions().getOrCreateSessionFromRequest(req);
-    const { oidc } = await scopedSession.getScopedSession();
+    // FIXME at this point the ScopedSession has already been cleared by sessionClearMiddleware
+    const { idToken } = await scopedSession.getScopedSession();
 
     // For IdPs that don't have end_session_endpoint, we just redirect to the requested page.
     if (this._skipEndSessionEndpoint) {
@@ -300,7 +307,7 @@ export class OIDCConfig {
     return this._client.endSessionUrl({
       // Ignore redirectUrl because OIDC providers don't allow variable redirect URIs
       post_logout_redirect_uri: stableRedirectUri,
-      id_token_hint: oidc?.idToken,
+      id_token_hint: idToken,
     });
   }
 
@@ -330,6 +337,13 @@ export class OIDCConfig {
         errMessage: userFriendlyMessage
       },
     });
+  }
+
+  private _getRequestWithSession(req: express.Request) {
+    const mreq = req as RequestWithLogin;
+    if (!mreq.session) { throw new Error('no session available'); }
+
+    return mreq;
   }
 
   private _buildEnabledProtections(section: AppSettings): Set<EnabledProtectionString> {

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -752,6 +752,7 @@ describe('OIDCConfig', () => {
   });
 
   describe('getLogoutRedirectUrl', () => {
+    const REDIRECT_URL = new URL('http://localhost:8484/docs/signed-out');
     const STABLE_LOGOUT_URL = new URL('http://localhost:8484/signed-out');
     const URL_RETURNED_BY_CLIENT = 'http://localhost:8484/logout_url_from_issuer';
     const ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT = 'http://localhost:8484/logout';
@@ -767,7 +768,7 @@ describe('OIDCConfig', () => {
         env: {
           GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT: 'true',
         },
-        expectedUrl: STABLE_LOGOUT_URL.href,
+        expectedUrl: REDIRECT_URL.href,
       }, {
         itMsg: 'should use the GRIST_OIDC_IDP_END_SESSION_ENDPOINT when it is set',
         env: {
@@ -803,7 +804,7 @@ describe('OIDCConfig', () => {
           },
           session: 'session' in ctx ? ctx.session : FAKE_SESSION
         } as unknown as RequestWithLogin;
-        const url = await config.getLogoutRedirectUrl(req);
+        const url = await config.getLogoutRedirectUrl(req, REDIRECT_URL);
         assert.equal(url, ctx.expectedUrl);
         if (ctx.expectedLogoutParams) {
           assert.isTrue(clientStub.endSessionUrl.calledOnce);

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -68,6 +68,9 @@ class FakeSessions {
 
       updateUser : async(req: express.Request, newProps: Partial<SessionUserObj>) => {
         Object.assign(this.user, newProps);
+        if (!this.user?.profile?.email) {
+          throw new Error("Unable to save SessionUserObj without email");
+        }
       }
     } as unknown as ScopedSession;
   }

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -21,7 +21,7 @@ async function buildOIDCConfigWith({
   sessions: Sessions;
   client: Client | null;
 }> = {}): Promise<OIDCConfig> {
-  const result: OIDCConfig = new OIDCConfig(sendAppPage, sessions);
+  const result: OIDCConfig = new OIDCConfig(sendAppPage, () => sessions);
   if (client !== null) {
     (result as any)._initClient = Sinon.spy(() => {
       (result as any)._client = client!;

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -1,6 +1,6 @@
 import {EnvironmentSnapshot} from "../testUtils";
 import {OIDCConfig} from "app/server/lib/OIDCConfig";
-import {SessionObj} from "app/server/lib/BrowserSession";
+import {ScopedSession, SessionUserObj} from "app/server/lib/BrowserSession";
 import {Sessions} from "app/server/lib/Sessions";
 import log from "app/server/lib/log";
 import {assert} from "chai";
@@ -8,27 +8,27 @@ import Sinon from "sinon";
 import {Client, custom, generators, errors as OIDCError} from "openid-client";
 import express from "express";
 import _ from "lodash";
-import {RequestWithLogin} from "app/server/lib/Authorizer";
 import { SendAppPageFunction } from "app/server/lib/sendAppPage";
 
 const NOOPED_SEND_APP_PAGE: SendAppPageFunction = () => Promise.resolve();
 
-class OIDCConfigStubbed extends OIDCConfig {
-  public static async buildWithStub(client: Client = new ClientStub().asClient()) {
-    return this.build(NOOPED_SEND_APP_PAGE, client);
+async function buildOIDCConfigWith({
+  sendAppPage = NOOPED_SEND_APP_PAGE,
+  sessions = new FakeSessions().asSessions(),
+  client = new ClientStub().asClient(),
+}: Partial<{
+  sendAppPage: SendAppPageFunction;
+  sessions: Sessions;
+  client: Client | null;
+}> = {}): Promise<OIDCConfig> {
+  const result: OIDCConfig = new OIDCConfig(sendAppPage, sessions);
+  if (client !== null) {
+    (result as any)._initClient = Sinon.spy(() => {
+      (result as any)._client = client!;
+    });
   }
-  public static async build(sendAppPage: SendAppPageFunction, clientStub?: Client): Promise<OIDCConfigStubbed> {
-    const result = new OIDCConfigStubbed(sendAppPage);
-    if (clientStub) {
-      result._initClient = Sinon.spy(() => {
-        result._client = clientStub!;
-      });
-    }
-    await result.initOIDC();
-    return result;
-  }
-
-  public _initClient: Sinon.SinonSpy;
+  await result.initOIDC();
+  return result;
 }
 
 class ClientStub {
@@ -52,6 +52,29 @@ class ClientStub {
   }
   public getAuthorizationUrlStub() {
     return this.authorizationUrl;
+  }
+}
+
+class FakeSessions {
+  public user: SessionUserObj;
+
+  constructor(initialUser: SessionUserObj = {}) {
+    this.user = _.clone(initialUser);
+  }
+
+  public getOrCreateSessionFromRequest(): ScopedSession {
+    return {
+      getScopedSession: async () => _.clone(this.user),
+
+      updateUser : async(req: express.Request, newProps: Partial<SessionUserObj>) => {
+        Object.assign(this.user, newProps);
+      }
+    } as unknown as ScopedSession;
+  }
+
+
+  public asSessions(): Sessions {
+    return this as unknown as Sessions;
   }
 }
 
@@ -107,21 +130,21 @@ describe('OIDCConfig', () => {
       ]) {
         setEnvVars();
         delete process.env[envVar];
-        const promise = OIDCConfig.build(NOOPED_SEND_APP_PAGE);
+        const promise = buildOIDCConfigWith();
         await assert.isRejected(promise, `missing environment variable: ${envVar}`);
       }
     });
 
     it('should reject when the client initialization fails', async () => {
       setEnvVars();
-      sandbox.stub(OIDCConfigStubbed.prototype, '_initClient').rejects(new Error('client init failed'));
-      const promise = OIDCConfigStubbed.build(NOOPED_SEND_APP_PAGE);
+      sandbox.stub(OIDCConfig.prototype as any, '_initClient').rejects(new Error('client init failed'));
+      const promise = buildOIDCConfigWith({ client: null });
       await assert.isRejected(promise, 'client init failed');
     });
 
     it('should create a client with passed information', async () => {
       setEnvVars();
-      const config = await OIDCConfigStubbed.buildWithStub();
+      const config: any = await buildOIDCConfigWith();
       assert.isTrue(config._initClient.calledOnce);
       assert.deepEqual(config._initClient.firstCall.args, [{
         clientId: process.env.GRIST_OIDC_IDP_CLIENT_ID,
@@ -139,7 +162,7 @@ describe('OIDCConfig', () => {
         userinfo_signed_response_alg: 'RS256',
       };
       process.env.GRIST_OIDC_IDP_EXTRA_CLIENT_METADATA = JSON.stringify(extraMetadata);
-      const config = await OIDCConfigStubbed.buildWithStub();
+      const config: any = await buildOIDCConfigWith();
       assert.isTrue(config._initClient.calledOnce);
       assert.deepEqual(config._initClient.firstCall.args, [{
         clientId: process.env.GRIST_OIDC_IDP_CLIENT_ID,
@@ -181,7 +204,7 @@ describe('OIDCConfig', () => {
           Object.assign(process.env, ctx.env);
           const client = new ClientStub();
           client.issuer.metadata.end_session_endpoint = ctx.end_session_endpoint;
-          const promise = OIDCConfigStubbed.buildWithStub(client.asClient());
+          const promise = buildOIDCConfigWith({ client: client.asClient() });
           if (ctx.errorMsg) {
             await assert.isRejected(promise, ctx.errorMsg);
             assert.isFalse(isInitializedLogCalled());
@@ -230,7 +253,7 @@ describe('OIDCConfig', () => {
           const setHttpOptionsDefaultsStub = sandbox.stub(custom, 'setHttpOptionsDefaults');
           setEnvVars();
           Object.assign(process.env, ctx.env);
-          const promise = OIDCConfigStubbed.buildWithStub();
+          const promise = buildOIDCConfigWith();
           if (ctx.expectedErrorMsg) {
             await assert.isRejected(promise, ctx.expectedErrorMsg);
           } else {
@@ -253,14 +276,14 @@ describe('OIDCConfig', () => {
     it('should reject when GRIST_OIDC_IDP_ENABLED_PROTECTIONS contains unsupported values', async () => {
       setEnvVars();
       process.env.GRIST_OIDC_IDP_ENABLED_PROTECTIONS = 'STATE,NONCE,PKCE,invalid';
-      const promise = OIDCConfig.build(NOOPED_SEND_APP_PAGE);
+      const promise = buildOIDCConfigWith();
       await checkRejection(promise, 'invalid');
     });
 
     it('should successfully change the supported protections', async function () {
       setEnvVars();
       process.env.GRIST_OIDC_IDP_ENABLED_PROTECTIONS = 'NONCE';
-      const config = await OIDCConfigStubbed.buildWithStub();
+      const config = await buildOIDCConfigWith();
       assert.isTrue(config.supportsProtection("NONCE"));
       assert.isFalse(config.supportsProtection("PKCE"));
       assert.isFalse(config.supportsProtection("STATE"));
@@ -269,14 +292,14 @@ describe('OIDCConfig', () => {
     it('should reject when set to an empty string', async function () {
       setEnvVars();
       process.env.GRIST_OIDC_IDP_ENABLED_PROTECTIONS = '';
-      const promise = OIDCConfigStubbed.buildWithStub();
+      const promise = buildOIDCConfigWith();
       await checkRejection(promise, '');
     });
 
     it('should accept to be set to "UNPROTECTED"', async function () {
       setEnvVars();
       process.env.GRIST_OIDC_IDP_ENABLED_PROTECTIONS = 'UNPROTECTED';
-      const config = await OIDCConfigStubbed.buildWithStub();
+      const config = await buildOIDCConfigWith();
       assert.isFalse(config.supportsProtection("NONCE"));
       assert.isFalse(config.supportsProtection("PKCE"));
       assert.isFalse(config.supportsProtection("STATE"));
@@ -287,13 +310,13 @@ describe('OIDCConfig', () => {
     it('should reject when set to "UNPROTECTED,PKCE"', async function () {
       setEnvVars();
       process.env.GRIST_OIDC_IDP_ENABLED_PROTECTIONS = 'UNPROTECTED,PKCE';
-      const promise = OIDCConfigStubbed.buildWithStub();
+      const promise = buildOIDCConfigWith();
       await checkRejection(promise, 'UNPROTECTED');
     });
 
     it('if omitted, should default to "STATE,PKCE"', async function () {
       setEnvVars();
-      const config = await OIDCConfigStubbed.buildWithStub();
+      const config = await buildOIDCConfigWith();
       assert.isFalse(config.supportsProtection("NONCE"));
       assert.isTrue(config.supportsProtection("PKCE"));
       assert.isTrue(config.supportsProtection("STATE"));
@@ -398,16 +421,19 @@ describe('OIDCConfig', () => {
         setEnvVars();
         Object.assign(process.env, ctx.env);
         const clientStub = new ClientStub();
-        const config = await OIDCConfigStubbed.buildWithStub(clientStub.asClient());
-        const session = {};
-        const req = {
-          session
-        } as unknown as express.Request;
+        const req = {} as unknown as express.Request;
+        const fakeSessions = new FakeSessions();
+        const config = await buildOIDCConfigWith({
+          sessions: fakeSessions.asSessions(),
+          client: clientStub.asClient()
+        });
+
         const url = await config.getLoginRedirectUrl(req, new URL(TARGET_URL));
+
         assert.equal(url, ClientStub.FAKE_REDIRECT_URL);
         assert.isTrue(clientStub.authorizationUrl.calledOnce);
         assert.deepEqual(clientStub.authorizationUrl.firstCall.args, ctx.expectedCalledWith);
-        assert.deepEqual(session, ctx.expectedSession);
+        assert.deepEqual(fakeSessions.user.oidc, ctx.expectedSession.oidc);
       });
     });
   });
@@ -421,12 +447,12 @@ describe('OIDCConfig', () => {
       name: 'fake-name',
       email_verified: true,
     };
-    const DEFAULT_SESSION = {
+    const DEFAULT_SESSION: SessionUserObj = {
       oidc: {
         code_verifier: FAKE_CODE_VERIFIER,
-        state: FAKE_STATE
-      }
-    } as SessionObj;
+        state: FAKE_STATE,
+      },
+    };
     const DEFAULT_EXPECTED_CALLBACK_CHECKS = {
       state: FAKE_STATE,
       code_verifier: FAKE_CODE_VERIFIER,
@@ -436,12 +462,7 @@ describe('OIDCConfig', () => {
       send: Sinon.SinonStub;
       redirect: Sinon.SinonStub;
     };
-    let fakeSessions: {
-      getOrCreateSessionFromRequest: Sinon.SinonStub
-    };
-    let fakeScopedSession: {
-      operateOnScopedSession: Sinon.SinonStub
-    };
+    const fakeSessions = new FakeSessions();
 
     beforeEach(() => {
       fakeRes = {
@@ -449,12 +470,7 @@ describe('OIDCConfig', () => {
         status: Sinon.stub().returnsThis(),
         send: Sinon.stub().returnsThis(),
       };
-      fakeScopedSession = {
-        operateOnScopedSession: Sinon.stub().resolves(),
-      };
-      fakeSessions = {
-        getOrCreateSessionFromRequest: Sinon.stub().returns(fakeScopedSession),
-      };
+      fakeSessions.user = {};
     });
 
     function checkUserProfile(expectedUserProfile: object) {
@@ -672,21 +688,21 @@ describe('OIDCConfig', () => {
         const fakeParams = {
           state: FAKE_STATE,
         };
-        const config = await OIDCConfigStubbed.build(sendAppPageStub as SendAppPageFunction, clientStub.asClient());
-        const session = _.clone(ctx.session); // session is modified, so clone it
-        const req = {
-          session,
-          t: (key: string) => key
-        } as unknown as express.Request;
+        const config = await buildOIDCConfigWith({
+          sendAppPage: sendAppPageStub as SendAppPageFunction,
+          sessions: fakeSessions.asSessions(),
+          client: clientStub.asClient()
+        });
         clientStub.callbackParams.returns(fakeParams);
         const tokenSet = { id_token: 'id_token', ...ctx.tokenSet };
         clientStub.callback.resolves(tokenSet);
         clientStub.userinfo.returns(_.clone(ctx.userInfo ?? FAKE_USER_INFO));
-        const user: { profile?: object } = {};
-        fakeScopedSession.operateOnScopedSession.yields(user);
+        fakeSessions.user = _.clone(ctx.session); // session is modified, so clone it
 
+        const req = {
+          t: (key: string) => key
+        } as unknown as express.Request;
         await config.handleCallback(
-          fakeSessions as unknown as Sessions,
           req,
           fakeRes as unknown as express.Response
         );
@@ -708,13 +724,11 @@ describe('OIDCConfig', () => {
             fakeParams,
             ctx.expectedCbChecks ?? DEFAULT_EXPECTED_CALLBACK_CHECKS
           ]);
-          assert.deepEqual(session, {
-            oidc: {
-              idToken: tokenSet.id_token,
-            }
+          assert.deepEqual(fakeSessions.user.oidc, {
+            idToken: tokenSet.id_token,
           }, 'oidc info should only keep state and id_token in the session and for the logout');
         }
-        ctx.extraChecks?.({ fakeRes, user, sendAppPageStub });
+        ctx.extraChecks?.({ fakeRes, user: fakeSessions.user, sendAppPageStub });
       });
     });
 
@@ -723,10 +737,12 @@ describe('OIDCConfig', () => {
       setEnvVars();
       const clientStub = new ClientStub();
       const sendAppPageStub = Sinon.stub().resolves();
-      const config = await OIDCConfigStubbed.build(sendAppPageStub, clientStub.asClient());
-      const req = {
-        session: DEFAULT_SESSION,
-      } as unknown as express.Request;
+      const config = await buildOIDCConfigWith({
+        sendAppPage: sendAppPageStub,
+        sessions: fakeSessions.asSessions(),
+        client: clientStub.asClient()
+      });
+      const req = {} as unknown as express.Request;
       clientStub.callbackParams.returns({state: FAKE_STATE});
       const errorResponse = {
         body: { property: 'response here' },
@@ -737,13 +753,15 @@ describe('OIDCConfig', () => {
       const err = new OIDCError.OPError({error: 'userinfo failed'}, errorResponse);
       clientStub.userinfo.rejects(err);
 
+      fakeSessions.user = _.clone(DEFAULT_SESSION);
       await config.handleCallback(
-        fakeSessions as unknown as Sessions,
         req,
         fakeRes as unknown as express.Response
       );
 
-      assert.equal(logErrorStub.callCount, 2, 'logErrorStub show be called twice');
+      assert.isUndefined(fakeSessions.user.oidc);
+
+      assert.equal(logErrorStub.callCount, 2, 'logErrorStub should be called twice');
       assert.include(logErrorStub.firstCall.args[0], err.message);
       assert.include(logErrorStub.secondCall.args[0], 'Response received');
       assert.deepEqual(logErrorStub.secondCall.args[1], errorResponse);
@@ -756,11 +774,11 @@ describe('OIDCConfig', () => {
     const STABLE_LOGOUT_URL = new URL('http://localhost:8484/signed-out');
     const URL_RETURNED_BY_CLIENT = 'http://localhost:8484/logout_url_from_issuer';
     const ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT = 'http://localhost:8484/logout';
-    const FAKE_SESSION = {
+    const FAKE_SESSION: SessionUserObj = {
       oidc: {
         idToken: 'id_token',
       }
-    } as SessionObj;
+    };
 
     [
       {
@@ -769,46 +787,60 @@ describe('OIDCConfig', () => {
           GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT: 'true',
         },
         expectedUrl: REDIRECT_URL.href,
-      }, {
+        session: FAKE_SESSION,
+      },
+      {
         itMsg: 'should use the GRIST_OIDC_IDP_END_SESSION_ENDPOINT when it is set',
         env: {
-          GRIST_OIDC_IDP_END_SESSION_ENDPOINT: ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT
+          GRIST_OIDC_IDP_END_SESSION_ENDPOINT:
+            ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT,
         },
-        expectedUrl: ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT
-      }, {
+        expectedUrl: ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT,
+        session: FAKE_SESSION,
+      },
+      {
         itMsg: 'should call the end session endpoint with the expected parameters',
         expectedUrl: URL_RETURNED_BY_CLIENT,
         expectedLogoutParams: {
           post_logout_redirect_uri: STABLE_LOGOUT_URL.href,
           id_token_hint: FAKE_SESSION.oidc!.idToken,
-        }
-      }, {
-        itMsg: 'should call the end session endpoint with no idToken if session is missing',
+        },
+        session: FAKE_SESSION,
+      },
+      {
+        itMsg: 'should call the end session endpoint with no idToken if session oidc info is missing',
         expectedUrl: URL_RETURNED_BY_CLIENT,
         expectedLogoutParams: {
           post_logout_redirect_uri: STABLE_LOGOUT_URL.href,
           id_token_hint: undefined,
         },
-        session: null
-      }
-    ].forEach(ctx => {
+        session: {},
+      },
+    ].forEach((ctx) => {
       it(ctx.itMsg, async () => {
         setEnvVars();
         Object.assign(process.env, ctx.env);
         const clientStub = new ClientStub();
         clientStub.endSessionUrl.returns(URL_RETURNED_BY_CLIENT);
-        const config = await OIDCConfigStubbed.buildWithStub(clientStub.asClient());
+
+        const fakeSessions = new FakeSessions(ctx.session);
+
+        const config = await buildOIDCConfigWith({
+          sessions: fakeSessions.asSessions(),
+          client: clientStub.asClient()
+        });
         const req = {
           headers: {
-            host: STABLE_LOGOUT_URL.host
+            host: STABLE_LOGOUT_URL.host,
           },
-          session: 'session' in ctx ? ctx.session : FAKE_SESSION
-        } as unknown as RequestWithLogin;
+        } as unknown as express.Request;
         const url = await config.getLogoutRedirectUrl(req, REDIRECT_URL);
         assert.equal(url, ctx.expectedUrl);
         if (ctx.expectedLogoutParams) {
           assert.isTrue(clientStub.endSessionUrl.calledOnce);
-          assert.deepEqual(clientStub.endSessionUrl.firstCall.args, [ctx.expectedLogoutParams]);
+          assert.deepEqual(clientStub.endSessionUrl.firstCall.args, [
+            ctx.expectedLogoutParams,
+          ]);
         }
       });
     });

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -1,6 +1,6 @@
 import {EnvironmentSnapshot} from "../testUtils";
 import {OIDCConfig} from "app/server/lib/OIDCConfig";
-import {ScopedSession, SessionUserObj} from "app/server/lib/BrowserSession";
+import {ScopedSession, SessionObj, SessionUserObj} from "app/server/lib/BrowserSession";
 import {Sessions} from "app/server/lib/Sessions";
 import log from "app/server/lib/log";
 import {assert} from "chai";
@@ -9,6 +9,7 @@ import {Client, custom, generators, errors as OIDCError} from "openid-client";
 import express from "express";
 import _ from "lodash";
 import { SendAppPageFunction } from "app/server/lib/sendAppPage";
+import { RequestWithLogin } from "app/server/lib/Authorizer";
 
 const NOOPED_SEND_APP_PAGE: SendAppPageFunction = () => Promise.resolve();
 
@@ -424,7 +425,10 @@ describe('OIDCConfig', () => {
         setEnvVars();
         Object.assign(process.env, ctx.env);
         const clientStub = new ClientStub();
-        const req = {} as unknown as express.Request;
+        const session: SessionObj = {};
+        const req = {
+          session
+        } as unknown as RequestWithLogin;
         const fakeSessions = new FakeSessions();
         const config = await buildOIDCConfigWith({
           sessions: fakeSessions.asSessions(),
@@ -436,7 +440,7 @@ describe('OIDCConfig', () => {
         assert.equal(url, ClientStub.FAKE_REDIRECT_URL);
         assert.isTrue(clientStub.authorizationUrl.calledOnce);
         assert.deepEqual(clientStub.authorizationUrl.firstCall.args, ctx.expectedCalledWith);
-        assert.deepEqual(fakeSessions.user.oidc, ctx.expectedSession.oidc);
+        assert.deepEqual(req.session.oidc, ctx.expectedSession.oidc);
       });
     });
   });
@@ -450,7 +454,7 @@ describe('OIDCConfig', () => {
       name: 'fake-name',
       email_verified: true,
     };
-    const DEFAULT_SESSION: SessionUserObj = {
+    const DEFAULT_SESSION: SessionObj = {
       oidc: {
         code_verifier: FAKE_CODE_VERIFIER,
         state: FAKE_STATE,
@@ -700,11 +704,12 @@ describe('OIDCConfig', () => {
         const tokenSet = { id_token: 'id_token', ...ctx.tokenSet };
         clientStub.callback.resolves(tokenSet);
         clientStub.userinfo.returns(_.clone(ctx.userInfo ?? FAKE_USER_INFO));
-        fakeSessions.user = _.clone(ctx.session); // session is modified, so clone it
-
+        fakeSessions.user = { profile: { name: 'test', email: "test@example.org" } };
+        const session = _.clone(ctx.session); // session is modified, so clone it
         const req = {
-          t: (key: string) => key
-        } as unknown as express.Request;
+          t: (key: string) => key,
+          session,
+        } as unknown as RequestWithLogin;
         await config.handleCallback(
           req,
           fakeRes as unknown as express.Response
@@ -727,9 +732,8 @@ describe('OIDCConfig', () => {
             fakeParams,
             ctx.expectedCbChecks ?? DEFAULT_EXPECTED_CALLBACK_CHECKS
           ]);
-          assert.deepEqual(fakeSessions.user.oidc, {
-            idToken: tokenSet.id_token,
-          }, 'oidc info should only keep state and id_token in the session and for the logout');
+          assert.isUndefined(session.oidc, 'oidc info should only keep state and id_token in the session and for the logout');
+          assert.equal(fakeSessions.user.idToken, tokenSet.id_token);
         }
         ctx.extraChecks?.({ fakeRes, user: fakeSessions.user, sendAppPageStub });
       });
@@ -745,7 +749,8 @@ describe('OIDCConfig', () => {
         sessions: fakeSessions.asSessions(),
         client: clientStub.asClient()
       });
-      const req = {} as unknown as express.Request;
+      const session = _.clone(DEFAULT_SESSION);
+      const req = { session } as RequestWithLogin;
       clientStub.callbackParams.returns({state: FAKE_STATE});
       const errorResponse = {
         body: { property: 'response here' },
@@ -756,13 +761,12 @@ describe('OIDCConfig', () => {
       const err = new OIDCError.OPError({error: 'userinfo failed'}, errorResponse);
       clientStub.userinfo.rejects(err);
 
-      fakeSessions.user = _.clone(DEFAULT_SESSION);
       await config.handleCallback(
         req,
         fakeRes as unknown as express.Response
       );
 
-      assert.isUndefined(fakeSessions.user.oidc);
+      assert.isUndefined(session.oidc);
 
       assert.equal(logErrorStub.callCount, 2, 'logErrorStub should be called twice');
       assert.include(logErrorStub.firstCall.args[0], err.message);
@@ -777,10 +781,8 @@ describe('OIDCConfig', () => {
     const STABLE_LOGOUT_URL = new URL('http://localhost:8484/signed-out');
     const URL_RETURNED_BY_CLIENT = 'http://localhost:8484/logout_url_from_issuer';
     const ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT = 'http://localhost:8484/logout';
-    const FAKE_SESSION: SessionUserObj = {
-      oidc: {
-        idToken: 'id_token',
-      }
+    const FAKE_USER_SESSION: SessionUserObj = {
+      idToken: "id_token",
     };
 
     [
@@ -790,7 +792,7 @@ describe('OIDCConfig', () => {
           GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT: 'true',
         },
         expectedUrl: REDIRECT_URL.href,
-        session: FAKE_SESSION,
+        user_session: FAKE_USER_SESSION,
       },
       {
         itMsg: 'should use the GRIST_OIDC_IDP_END_SESSION_ENDPOINT when it is set',
@@ -799,16 +801,16 @@ describe('OIDCConfig', () => {
             ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT,
         },
         expectedUrl: ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT,
-        session: FAKE_SESSION,
+        user_session: FAKE_USER_SESSION,
       },
       {
         itMsg: 'should call the end session endpoint with the expected parameters',
         expectedUrl: URL_RETURNED_BY_CLIENT,
         expectedLogoutParams: {
           post_logout_redirect_uri: STABLE_LOGOUT_URL.href,
-          id_token_hint: FAKE_SESSION.oidc!.idToken,
+          id_token_hint: FAKE_USER_SESSION.idToken,
         },
-        session: FAKE_SESSION,
+        user_session: FAKE_USER_SESSION,
       },
       {
         itMsg: 'should call the end session endpoint with no idToken if session oidc info is missing',
@@ -817,7 +819,7 @@ describe('OIDCConfig', () => {
           post_logout_redirect_uri: STABLE_LOGOUT_URL.href,
           id_token_hint: undefined,
         },
-        session: {},
+        user_session: {},
       },
     ].forEach((ctx) => {
       it(ctx.itMsg, async () => {
@@ -826,7 +828,7 @@ describe('OIDCConfig', () => {
         const clientStub = new ClientStub();
         clientStub.endSessionUrl.returns(URL_RETURNED_BY_CLIENT);
 
-        const fakeSessions = new FakeSessions(ctx.session);
+        const fakeSessions = new FakeSessions(ctx.user_session);
 
         const config = await buildOIDCConfigWith({
           sessions: fakeSessions.asSessions(),


### PR DESCRIPTION
- **getLogoutRedirectUrl minor improvements**
- **Move oidc session info from SessionObj to SessionUserObj**
- **OIDCConfig test refactoring**
- **OIDCConfig refactoring**
- **use getScopedSession for read-only access**
- **stop using operateOnScopedSession**
- **proposal for buildOIDCConfigWith**
